### PR TITLE
algorithm edge case

### DIFF
--- a/WordleClash.Core/WordHandler.cs
+++ b/WordleClash.Core/WordHandler.cs
@@ -17,7 +17,7 @@ public class WordHandler
     
     public LetterResult[] GetFeedback(string guessedWord)
     {
-        var feedbackList = new LetterResult[Word.Length];
+        var feedbackList = new List<LetterResult>();
         for (var i = 0; i < guessedWord.Length; i++)
         {
             LetterFeedback feedback;
@@ -34,15 +34,21 @@ public class WordHandler
             else
             {
                 feedback = LetterFeedback.IncorrectPosition;
+                var feedbackListLetterCount = feedbackList.Count(r => r.Letter == letter);
+                var wordLetterCount = Word.Count(c => c == letter);
+                if (feedbackListLetterCount >= wordLetterCount)
+                {
+                    feedback = LetterFeedback.IncorrectLetter;
+                }
             }
 
-            feedbackList[i] = new LetterResult
+            feedbackList.Add(new LetterResult
             {
                 Letter = letter,
                 Feedback = feedback
-            };
+            });
         }
-        return feedbackList;
+        return feedbackList.ToArray();
     }
     
     private List<int> GetAllIndexesOf(char letter)

--- a/WordleClash.Tests/Tests/CoreGameLogic/WordFeedbackTests.cs
+++ b/WordleClash.Tests/Tests/CoreGameLogic/WordFeedbackTests.cs
@@ -78,5 +78,50 @@ public class WordFeedBackTests
         ];
         Assert.That(feedback, Is.EqualTo(expectedFeedback));
     }
+    
+    [Test]
+    public void SameLetterIncorrectPositions()
+    {
+        var feedback = TestHelpers.ExtractFeedbackFromGuess("tophe", "trees");
+        LetterFeedback[] expectedFeedback =
+        [
+            LetterFeedback.CorrectPosition,
+            LetterFeedback.IncorrectLetter,
+            LetterFeedback.IncorrectPosition,
+            LetterFeedback.IncorrectLetter,
+            LetterFeedback.IncorrectLetter,
+        ];
+        Assert.That(feedback, Is.EqualTo(expectedFeedback));
+    }
+    
+    [Test]
+    public void SameLetterIncorrectAndCorrect()
+    {
+        var feedback = TestHelpers.ExtractFeedbackFromGuess("glued", "bleed");
+        LetterFeedback[] expectedFeedback =
+        [
+            LetterFeedback.IncorrectLetter,
+            LetterFeedback.CorrectPosition,
+            LetterFeedback.IncorrectPosition,
+            LetterFeedback.CorrectPosition,
+            LetterFeedback.CorrectPosition,
+        ];
+        Assert.That(feedback, Is.EqualTo(expectedFeedback));
+    }
+    
+    [Test]
+    public void InconsistentCasing()
+    {
+        var feedback = TestHelpers.ExtractFeedbackFromGuess("aBcDe", "AbCdE");
+        LetterFeedback[] expectedFeedback =
+        [
+            LetterFeedback.CorrectPosition,
+            LetterFeedback.CorrectPosition,
+            LetterFeedback.CorrectPosition,
+            LetterFeedback.CorrectPosition,
+            LetterFeedback.CorrectPosition,
+        ];
+        Assert.That(feedback, Is.EqualTo(expectedFeedback));
+    }
 
 }


### PR DESCRIPTION
this PR handles an edge case where the 2nd guessed letter would have the wrong color.
for e.g. if the target word is "TOPHE" and the user guesses "TREES" both E's would be colored yellow, while instead on the 2nd occurence we should make it gray since we already tagged the first occurence of the E in the guess as yellow and there is only one E in TOPHE